### PR TITLE
Add the option to define the target branch on the created pull requests

### DIFF
--- a/bin/cml.test.js
+++ b/bin/cml.test.js
@@ -8,7 +8,7 @@ describe('command-line interface tests', () => {
     expect(output).toMatchInlineSnapshot(`
       "cml.js <command>
 
-      Commands:
+      Comandos:
         cml.js check              Manage CI checks
         cml.js comment            Manage comments
         cml.js pr <glob path...>  Manage pull requests
@@ -19,18 +19,19 @@ describe('command-line interface tests', () => {
 
       Global Options:
         --log                    Logging verbosity
-                [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+        [cadena de caracteres] [selección: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [defecto:
+                                                                               \\"info\\"]
         --driver                 Git provider where the repository is hosted
-          [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
-                                                                          environment]
+         [cadena de caracteres] [selección: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [defecto:
+                                                           infer from the environment]
         --repo                   Repository URL or slug
-                                        [string] [default: infer from the environment]
+                          [cadena de caracteres] [defecto: infer from the environment]
         --driver-token, --token  CI driver personal/project access token (PAT)
-                                        [string] [default: infer from the environment]
-        --help                   Show help                                   [boolean]
+                          [cadena de caracteres] [defecto: infer from the environment]
+        --help                   Muestra ayuda                              [booleano]
 
-      Options:
-        --version  Show version number                                       [boolean]"
+      Opciones:
+        --version  Muestra número de versión                                [booleano]"
     `);
   });
 });

--- a/bin/cml/asset/publish.test.js
+++ b/bin/cml/asset/publish.test.js
@@ -9,23 +9,26 @@ describe('CML cli test', () => {
 
       Global Options:
             --log                    Logging verbosity
-                [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+        [cadena de caracteres] [selección: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [defecto:
+                                                                               \\"info\\"]
             --driver                 Git provider where the repository is hosted
-          [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
-                                                                          environment]
+         [cadena de caracteres] [selección: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [defecto:
+                                                           infer from the environment]
             --repo                   Specifies the repo to be used. If not specified
                                      is extracted from the CI ENV.
-                                        [string] [default: infer from the environment]
+                          [cadena de caracteres] [defecto: infer from the environment]
             --driver-token, --token  CI driver personal/project access token (PAT)
-                                        [string] [default: infer from the environment]
-            --help                   Show help                               [boolean]
+                          [cadena de caracteres] [defecto: infer from the environment]
+            --help                   Muestra ayuda                          [booleano]
 
-      Options:
-            --md         Output in markdown format [title || name](url)      [boolean]
-        -t, --title      Markdown title [title](url) or ![](url title)        [string]
+      Opciones:
+            --md         Output in markdown format [title || name](url)     [booleano]
+        -t, --title      Markdown title [title](url) or ![](url title)
+                                                                [cadena de caracteres]
             --native     Uses driver's native capabilities to upload assets instead of
-                         CML's storage; not available on GitHub              [boolean]
-            --mime-type  MIME type    [string] [default: infer from the file contents]"
+                         CML's storage; not available on GitHub             [booleano]
+            --mime-type  MIME type
+                        [cadena de caracteres] [defecto: infer from the file contents]"
     `);
   });
 });

--- a/bin/cml/check/create.test.js
+++ b/bin/cml/check/create.test.js
@@ -14,27 +14,29 @@ describe('CML e2e', () => {
 
       Global Options:
         --log                    Logging verbosity
-                [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+        [cadena de caracteres] [selección: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [defecto:
+                                                                               \\"info\\"]
         --driver                 Git provider where the repository is hosted
-          [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
-                                                                          environment]
+         [cadena de caracteres] [selección: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [defecto:
+                                                           infer from the environment]
         --repo                   Repository URL or slug
-                                        [string] [default: infer from the environment]
+                          [cadena de caracteres] [defecto: infer from the environment]
         --driver-token, --token  GITHUB_TOKEN or Github App token. Personal access
                                  token won't work
-                                        [string] [default: infer from the environment]
-        --help                   Show help                                   [boolean]
+                          [cadena de caracteres] [defecto: infer from the environment]
+        --help                   Muestra ayuda                              [booleano]
 
-      Options:
+      Opciones:
         --commit-sha, --head-sha  Commit SHA linked to this comment
-                                                              [string] [default: HEAD]
+                                                [cadena de caracteres] [defecto: HEAD]
         --conclusion              Conclusion status of the check
-           [string] [choices: \\"success\\", \\"failure\\", \\"neutral\\", \\"cancelled\\", \\"skipped\\",
-                                                     \\"timed_out\\"] [default: \\"success\\"]
+                   [cadena de caracteres] [selección: \\"success\\", \\"failure\\", \\"neutral\\",
+                             \\"cancelled\\", \\"skipped\\", \\"timed_out\\"] [defecto: \\"success\\"]
         --status                  Status of the check
-                    [string] [choices: \\"queued\\", \\"in_progress\\", \\"completed\\"] [default:
-                                                                          \\"completed\\"]
-        --title                   Title of the check  [string] [default: \\"CML Report\\"]"
+              [cadena de caracteres] [selección: \\"queued\\", \\"in_progress\\", \\"completed\\"]
+                                                                [defecto: \\"completed\\"]
+        --title                   Title of the check
+                                        [cadena de caracteres] [defecto: \\"CML Report\\"]"
     `);
   });
 });

--- a/bin/cml/comment/create.test.js
+++ b/bin/cml/comment/create.test.js
@@ -8,32 +8,34 @@ describe('Comment integration tests', () => {
 
       Global Options:
         --log                    Logging verbosity
-                [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+        [cadena de caracteres] [selección: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [defecto:
+                                                                               \\"info\\"]
         --driver                 Git provider where the repository is hosted
-          [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
-                                                                          environment]
+         [cadena de caracteres] [selección: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [defecto:
+                                                           infer from the environment]
         --repo                   Repository URL or slug
-                                        [string] [default: infer from the environment]
+                          [cadena de caracteres] [defecto: infer from the environment]
         --driver-token, --token  CI driver personal/project access token (PAT)
-                                        [string] [default: infer from the environment]
-        --help                   Show help                                   [boolean]
+                          [cadena de caracteres] [defecto: infer from the environment]
+        --help                   Muestra ayuda                              [booleano]
 
-      Options:
+      Opciones:
         --target                    Comment type (\`commit\`, \`pr\`, \`commit/f00bar\`,
                                     \`pr/42\`, \`issue/1337\`),default is automatic (\`pr\`
-                                    but fallback to \`commit\`).                [string]
+                                    but fallback to \`commit\`).  [cadena de caracteres]
         --watch                     Watch for changes and automatically update the
-                                    comment                                  [boolean]
+                                    comment                                 [booleano]
         --publish                   Upload any local images found in the Markdown
-                                    report                   [boolean] [default: true]
+                                    report                  [booleano] [defecto: true]
         --publish-url               Self-hosted image server URL
-                                           [string] [default: \\"https://asset.cml.dev\\"]
+                             [cadena de caracteres] [defecto: \\"https://asset.cml.dev\\"]
         --publish-native, --native  Uses driver's native capabilities to upload assets
                                     instead of CML's storage; not available on GitHub
-                                                                             [boolean]
+                                                                            [booleano]
         --watermark-title           Hidden comment marker (used for targeting in
                                     subsequent \`cml comment update\`); \\"{workflow}\\" &
-                                    \\"{run}\\" are auto-replaced   [string] [default: \\"\\"]"
+                                    \\"{run}\\" are auto-replaced
+                                                  [cadena de caracteres] [defecto: \\"\\"]"
     `);
   });
 });

--- a/bin/cml/pr/create.e2e.test.js
+++ b/bin/cml/pr/create.e2e.test.js
@@ -9,22 +9,23 @@ describe('CML e2e', () => {
 
       Manage pull requests
 
-      Commands:
+      Comandos:
         cml.js pr create [glob path...]  Create a pull request (committing any given
                                          paths first)
                                          https://cml.dev/doc/ref/pr
 
       Global Options:
         --log                    Logging verbosity
-                [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+        [cadena de caracteres] [selección: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [defecto:
+                                                                               \\"info\\"]
         --driver                 Git provider where the repository is hosted
-          [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
-                                                                          environment]
+         [cadena de caracteres] [selección: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [defecto:
+                                                           infer from the environment]
         --repo                   Repository URL or slug
-                                        [string] [default: infer from the environment]
+                          [cadena de caracteres] [defecto: infer from the environment]
         --driver-token, --token  CI driver personal/project access token (PAT)
-                                        [string] [default: infer from the environment]
-        --help                   Show help                                   [boolean]"
+                          [cadena de caracteres] [defecto: infer from the environment]
+        --help                   Muestra ayuda                              [booleano]"
     `);
   });
 });

--- a/bin/cml/pr/create.js
+++ b/bin/cml/pr/create.js
@@ -54,6 +54,10 @@ exports.options = kebabcaseKeys({
     type: 'string',
     description: 'Pull request branch name'
   },
+  targetBranch: {
+    type: 'string',
+    description: 'Pull request target branch name'
+  },
   title: {
     type: 'string',
     description: 'Pull request title'

--- a/bin/cml/repo/prepare.test.js
+++ b/bin/cml/repo/prepare.test.js
@@ -11,21 +11,23 @@ describe('CML e2e', () => {
 
       Global Options:
         --log                    Logging verbosity
-                [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+        [cadena de caracteres] [selección: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [defecto:
+                                                                               \\"info\\"]
         --driver                 Git provider where the repository is hosted
-          [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
-                                                                          environment]
+         [cadena de caracteres] [selección: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [defecto:
+                                                           infer from the environment]
         --repo                   Repository URL or slug
-                                        [string] [default: infer from the environment]
+                          [cadena de caracteres] [defecto: infer from the environment]
         --driver-token, --token  CI driver personal/project access token (PAT)
-                                        [string] [default: infer from the environment]
-        --help                   Show help                                   [boolean]
+                          [cadena de caracteres] [defecto: infer from the environment]
+        --help                   Muestra ayuda                              [booleano]
 
-      Options:
+      Opciones:
         --fetch-depth  Number of commits to fetch (use \`0\` for all branches & tags)
-                                                                              [number]
-        --user-email   Git user email        [string] [default: \\"olivaw@iterative.ai\\"]
-        --user-name    Git user name                 [string] [default: \\"Olivaw[bot]\\"]"
+                                                                              [número]
+        --user-email   Git user email
+                               [cadena de caracteres] [defecto: \\"olivaw@iterative.ai\\"]
+        --user-name    Git user name   [cadena de caracteres] [defecto: \\"Olivaw[bot]\\"]"
     `);
   });
 });

--- a/bin/cml/runner/launch.test.js
+++ b/bin/cml/runner/launch.test.js
@@ -9,21 +9,22 @@ describe('CML e2e', () => {
 
       Manage self-hosted (cloud & on-premise) CI runners
 
-      Commands:
+      Comandos:
         cml.js runner launch  Launch and register a self-hosted runner
                               https://cml.dev/doc/ref/runner
 
       Global Options:
         --log                    Logging verbosity
-                [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+        [cadena de caracteres] [selección: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [defecto:
+                                                                               \\"info\\"]
         --driver                 Git provider where the repository is hosted
-          [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
-                                                                          environment]
+         [cadena de caracteres] [selección: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [defecto:
+                                                           infer from the environment]
         --repo                   Repository URL or slug
-                                        [string] [default: infer from the environment]
+                          [cadena de caracteres] [defecto: infer from the environment]
         --driver-token, --token  CI driver personal/project access token (PAT)
-                                        [string] [default: infer from the environment]
-        --help                   Show help                                   [boolean]"
+                          [cadena de caracteres] [defecto: infer from the environment]
+        --help                   Muestra ayuda                              [booleano]"
     `);
   });
 });

--- a/bin/cml/tensorboard/connect.test.js
+++ b/bin/cml/tensorboard/connect.test.js
@@ -14,27 +14,30 @@ describe('CML e2e', () => {
 
       Global Options:
             --log                    Logging verbosity
-                [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+        [cadena de caracteres] [selección: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [defecto:
+                                                                               \\"info\\"]
             --driver                 Git provider where the repository is hosted
-          [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
-                                                                          environment]
+         [cadena de caracteres] [selección: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [defecto:
+                                                           infer from the environment]
             --repo                   Repository URL or slug
-                                        [string] [default: infer from the environment]
+                          [cadena de caracteres] [defecto: infer from the environment]
             --driver-token, --token  CI driver personal/project access token (PAT)
-                                        [string] [default: infer from the environment]
-            --help                   Show help                               [boolean]
+                          [cadena de caracteres] [defecto: infer from the environment]
+            --help                   Muestra ayuda                          [booleano]
 
-      Options:
+      Opciones:
         -c, --credentials  TensorBoard credentials as JSON, usually found at
                            ~/.config/tensorboard/credentials/uploader-creds.json
-                                                                   [string] [required]
-            --logdir       Directory containing the logs to process           [string]
-            --name         Tensorboard experiment title; max 100 characters   [string]
+                                                    [cadena de caracteres] [requerido]
+            --logdir       Directory containing the logs to process
+                                                                [cadena de caracteres]
+            --name         Tensorboard experiment title; max 100 characters
+                                                                [cadena de caracteres]
             --description  Tensorboard experiment description in Markdown format; max
-                           600 characters                                     [string]
-            --md           Output as markdown [title || name](url)           [boolean]
+                           600 characters                       [cadena de caracteres]
+            --md           Output as markdown [title || name](url)          [booleano]
         -t, --title        Markdown title, if not specified, param name will be used
-                                                                              [string]"
+                                                                [cadena de caracteres]"
     `);
   });
 });

--- a/bin/cml/workflow/rerun.test.js
+++ b/bin/cml/workflow/rerun.test.js
@@ -14,18 +14,19 @@ describe('CML e2e', () => {
 
       Global Options:
         --log                    Logging verbosity
-                [string] [choices: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [default: \\"info\\"]
+        [cadena de caracteres] [selección: \\"error\\", \\"warn\\", \\"info\\", \\"debug\\"] [defecto:
+                                                                               \\"info\\"]
         --driver                 Git provider where the repository is hosted
-          [string] [choices: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [default: infer from the
-                                                                          environment]
+         [cadena de caracteres] [selección: \\"github\\", \\"gitlab\\", \\"bitbucket\\"] [defecto:
+                                                           infer from the environment]
         --repo                   Repository URL or slug
-                                        [string] [default: infer from the environment]
+                          [cadena de caracteres] [defecto: infer from the environment]
         --driver-token, --token  CI driver personal/project access token (PAT)
-                                        [string] [default: infer from the environment]
-        --help                   Show help                                   [boolean]
+                          [cadena de caracteres] [defecto: infer from the environment]
+        --help                   Muestra ayuda                              [booleano]
 
-      Options:
-        --id  Run identifier to be rerun                                      [string]"
+      Opciones:
+        --id  Run identifier to be rerun                        [cadena de caracteres]"
     `);
   });
 });

--- a/src/cml.js
+++ b/src/cml.js
@@ -547,7 +547,18 @@ class CML {
     const shaShort = sha.substr(0, 8);
 
     let target = await this.branch();
-    if (targetBranch) {
+    const targetBranchExists =
+      targetBranch &&
+      (
+        await exec(
+          'git',
+          'ls-remote',
+          await exec('git', 'config', '--get', `remote.${remote}.url`),
+          targetBranch
+        )
+      ).includes(targetBranch);
+
+    if (targetBranchExists) {
       target = targetBranch;
     }
     const source = branch || `${target}-cml-pr-${shaShort}`;

--- a/src/cml.js
+++ b/src/cml.js
@@ -22,7 +22,7 @@ const {
   waitForever
 } = require('./utils');
 const { Watermark } = require('./watermark');
-const { GITHUB_REPOSITORY, CI_PROJECT_URL, BITBUCKET_REPO_UUID, TARGET_BRANCH } = process.env;
+const { GITHUB_REPOSITORY, CI_PROJECT_URL, BITBUCKET_REPO_UUID } = process.env;
 
 const GIT_USER_NAME = 'Olivaw[bot]';
 const GIT_USER_EMAIL = 'olivaw@iterative.ai';
@@ -508,6 +508,7 @@ class CML {
       md,
       skipCi,
       branch,
+      targetBranch,
       message,
       title,
       body,
@@ -546,8 +547,8 @@ class CML {
     const shaShort = sha.substr(0, 8);
 
     let target = await this.branch();
-    if (TARGET_BRANCH) {
-      target = TARGET_BRANCH;
+    if (targetBranch) {
+      target = targetBranch;
     }
     const source = branch || `${target}-cml-pr-${shaShort}`;
 

--- a/src/cml.js
+++ b/src/cml.js
@@ -22,7 +22,7 @@ const {
   waitForever
 } = require('./utils');
 const { Watermark } = require('./watermark');
-const { GITHUB_REPOSITORY, CI_PROJECT_URL, BITBUCKET_REPO_UUID } = process.env;
+const { GITHUB_REPOSITORY, CI_PROJECT_URL, BITBUCKET_REPO_UUID, TARGET_BRANCH } = process.env;
 
 const GIT_USER_NAME = 'Olivaw[bot]';
 const GIT_USER_EMAIL = 'olivaw@iterative.ai';
@@ -545,7 +545,10 @@ class CML {
     const sha = await this.triggerSha();
     const shaShort = sha.substr(0, 8);
 
-    const target = await this.branch();
+    let target = await this.branch();
+    if (TARGET_BRANCH) {
+      target = TARGET_BRANCH;
+    }
     const source = branch || `${target}-cml-pr-${shaShort}`;
 
     const branchExists = (


### PR DESCRIPTION
Adds the option to select the target branch of the PR to be created, instead of defaulting to the branch from where it's executed.

Example where the PR will be created with the `main` branch as the target branch:
`cml pr create . --targetBranch=main`